### PR TITLE
fix display of total

### DIFF
--- a/templates/extra_fee.tpl
+++ b/templates/extra_fee.tpl
@@ -35,7 +35,7 @@ CRM.$(function($) {
   function displayTotalAmount(totalfee) {
     totalfee = Math.round(totalfee*100)/100;
     var totalEventFee  = formatExtraFee( totalfee, 2, separator, thousandMarker);
-    $('#pricevalue').innerHTML = "<b>" + symbol + "</b> " + totalEventFee;
+    $('#pricevalue')[0].innerHTML = "<b>" + symbol + "</b> " + totalEventFee;
 
     $('#total_amount').val( totalfee );
     $('#pricevalue').data('raw-total', totalfee).trigger('change');


### PR DESCRIPTION
It looks like the most recent commit broke the update of the total amount.  Using `$('#total_amount')` doesn't return a DOM element, it returns a collection with a single DOM element.  This PR fixes it.

I was originally going to use vanilla JS, but it looks like that's what it was before the fix.  Since I don't understand what about the code caused #7, this seemed like a safer approach.