### PR TITLE
Total price isn't appearing when page doesn't use a price set

### DIFF
--- a/templates/extra_fee.tpl
+++ b/templates/extra_fee.tpl
@@ -40,7 +40,7 @@ CRM.$(function($) {
     $('#total_amount').val( totalfee );
     $('#pricevalue').data('raw-total', totalfee).trigger('change');
 
-    ( totalfee < 0 ) ? $('table#pricelabel').addClass('disabled') : $('table#pricelabel').removeClass('disabled');
+    ( totalfee < 0 ) ? $('#pricelabel, #pricevalue').hide() : $('#pricelabel, #pricevalue').show();
   }
 
   function formatExtraFee(amount, c, d, t){


### PR DESCRIPTION
It looks like this used to work but the Javascript got a little out of date.  This works with modern CiviCRM.