### PR TITLE
Fix total amount token for optional setting and more fixes

### DIFF
--- a/CRM/Extrafee/Fee.php
+++ b/CRM/Extrafee/Fee.php
@@ -40,8 +40,7 @@ class CRM_Extrafee_Fee {
   }
 
   public static function addOptionalFeeCheckbox($form, $extraFeeSettings) {
-    $message = $extraFeeSettings['message'];
-    $form->add('checkbox', 'extra_fee_add', $message);
+    $form->add('checkbox', 'extra_fee_add', $extraFeeSettings['label']);
   }
 
   /**

--- a/CRM/Extrafee/Form/ExtraFeeSettings.php
+++ b/CRM/Extrafee/Form/ExtraFeeSettings.php
@@ -22,6 +22,7 @@ class CRM_Extrafee_Form_ExtraFeeSettings extends CRM_Core_Form {
       'extra_fee_message' => CRM_Utils_Array::value('message', $extraFeeSettings, 'A 1.7% credit card fee and 20c processing fee will apply.'),
       'extra_fee_paymentprocessors' => CRM_Utils_Array::value('paymentprocessors', $extraFeeSettings, []),
       'extra_fee_optional' => CRM_Utils_Array::value('optional', $extraFeeSettings, FALSE),
+      'extra_fee_label' => CRM_Utils_Array::value('label', $extraFeeSettings, 'Include Extra Fee?'),
     ];
     return $defaults;
   }
@@ -41,6 +42,7 @@ class CRM_Extrafee_Form_ExtraFeeSettings extends CRM_Core_Form {
     ]);
 
     $this->add('advcheckbox', 'extra_fee_optional', ts('Extra fee is optional'));
+    $this->add('text', 'extra_fee_label', ts('Label'));
 
     $this->addButtons(array(
       array(
@@ -58,11 +60,12 @@ class CRM_Extrafee_Form_ExtraFeeSettings extends CRM_Core_Form {
   public function postProcess() {
     $values = $this->exportValues();
     $extraFeeSettings = [
-      'percent' => CRM_Utils_Array::value('extra_fee_percentage', $values),
-      'processing_fee' => CRM_Utils_Array::value('extra_fee_processing_fee', $values),
-      'message' => addslashes(CRM_Utils_Array::value('extra_fee_message', $values)),
-      'paymentprocessors' => CRM_Utils_Array::value('extra_fee_paymentprocessors', $values),
-      'optional' => CRM_Utils_Array::value('extra_fee_optional', $values),
+      'percent' => $values['extra_fee_percentage'] ?? NULL,
+      'processing_fee' => $values['extra_fee_percentage'] ?? NULL,
+      'message' => addslashes($values['extra_fee_message']),
+      'paymentprocessors' => $values['extra_fee_paymentprocessors'] ?? NULL,
+      'optional' => $values['extra_fee_optional'] ?? NULL,
+      'label' => $values['extra_fee_label'] ?? NULL,
     ];
     Civi::settings()->set('extra_fee_settings', json_encode($extraFeeSettings));
     CRM_Core_Session::setStatus(E::ts('You settings are saved.'), 'Success', 'success');

--- a/templates/CRM/Extrafee/Form/ExtraFeeSettings.tpl
+++ b/templates/CRM/Extrafee/Form/ExtraFeeSettings.tpl
@@ -16,6 +16,9 @@
     {if $elementName EQ 'extra_fee_paymentprocessors'}
       <div class='content description'>If you enable this for a payment processor then the Extra Fee will apply to all payment processors that are enabled on the same contribution/event page. Leave blank to apply to all contribution/event pages.</div>
     {/if}
+    {if $elementName EQ 'extra_fee_optional'}
+      <div class='content description'>If checked, an optional checkbox is displayed on the form to add extra fee on the total amount.</div>
+    {/if}
     <div class="clear"></div>
   </div>
 {/foreach}
@@ -24,3 +27,12 @@
 <div class="crm-submit-buttons">
 {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
+{literal}
+<script>
+  CRM.$(function($) {
+    $('#extra_fee_optional').change(function() {
+      $('#extra_fee_label').closest('div.crm-section').toggle($(this).is(':checked'));
+    }).trigger('change');
+  });
+</script>
+{/literal}

--- a/templates/extra_fee.tpl
+++ b/templates/extra_fee.tpl
@@ -9,25 +9,29 @@ CRM.$(function($) {
   var thousandMarker = '{/literal}{$config->monetaryThousandSeparator}{literal}';
   var separator      = '{/literal}{$config->monetaryDecimalPoint}{literal}';
   var symbol         = '{/literal}{$currencySymbol}{literal}';
+  var optional_input = msg = '';
 
-  {/literal}{if $extraFeeOptional}{literal}
-    $msg = '<div class="content" id="extra_fee_checkbox">{/literal}{$form.extra_fee_add.html} {$form.extra_fee_add.label}{literal}</div><br />';
-  {/literal}{else}{literal}
-    $msg = '<div class="content" id="extra_fee_msg">'+ message.replace(/{total_amount}/g, "0") +'</div><br />';
-  {/literal}{/if}{literal}
+  {/literal}
+    {if $extraFeeOptional}
+      {literal}
+        optional_input = '<div class="content" id="extra_fee_checkbox">{/literal}{$form.extra_fee_add.html} {$form.extra_fee_add.label}{literal}</div><br />';
+      {/literal}
+    {/if}
+  {literal}
+  msg = '<div class="content" id="extra_fee_msg">'+ message.replace(/{total_amount}/g, "0") +'</div><br />';
   if (payNowPayment) {
     if (isQuickConfig) {
-      $('#total_amount').closest('div').append($msg);
+      $('#total_amount').closest('div').append(optional_input + msg);
     }
     else {
-      $('.total_amount-section').append($msg);
+      $('.total_amount-section').append(optional_input + msg);
     }
   }
   else if (isQuickConfig) {
-    $('#priceset').append($msg);
+    $('#priceset').append(optional_input + msg);
   }
   else {
-    $('#pricesetTotal').append($msg);
+    $('#pricesetTotal').append(optional_input + msg);
   }
 
   $('input#extra_fee_add').on('change', function() { displayTotalAmount(calculateTotalFee()); });


### PR DESCRIPTION
Fixes https://github.com/fuzionnz/nz.co.fuzion.extrafee/issues/11

A new field is added on the form to collect the label of the optional checkbox element.

![image](https://user-images.githubusercontent.com/5929648/105033649-63b33480-5a7e-11eb-9db5-caa46482f6e1.png)

{total_amount} token works if extra fee is enabled. 

![image](https://user-images.githubusercontent.com/5929648/105033700-775e9b00-5a7e-11eb-9078-011d3d4695f2.png)

@MegaphoneJon 