### PR TITLE
avoid rounding errors.

### DIFF
--- a/templates/extra_fee.tpl
+++ b/templates/extra_fee.tpl
@@ -32,8 +32,18 @@ CRM.$(function($) {
 
   $('input#extra_fee_add').on('change', function() { displayTotalAmount(calculateTotalFee()); });
 
+  /*
+   * Thanks: https://stackoverflow.com/a/59268677/11400326
+   */
+  function roundNumber(num) {
+    // Return a number the is rounded and two decimals. Ensure a "5" is rounded up
+    // rather then down (which varies depending on the browser). For more info, see:
+    // https://stackoverflow.com/questions/10015027/javascript-tofixed-not-rounding
+    precision = 2;
+    return (+(Math.round(+(num + 'e' + precision)) + 'e' + -precision)).toFixed(precision);
+  }
   function displayTotalAmount(totalfee) {
-    totalfee = Math.round(totalfee*100)/100;
+    totalfee = roundNumber(totalfee);
     var totalEventFee  = formatExtraFee( totalfee, 2, separator, thousandMarker);
     $('#pricevalue').innerHTML = "<b>" + symbol + "</b> " + totalEventFee;
 
@@ -79,11 +89,12 @@ CRM.$(function($) {
     $('#extra_fee_msg').hide();
 
     if (totalFee > totalWithoutTax) {
-      var newhtml = message.replace(/{total_amount}/g, Math.round(totalFee * 100)/100);
+      var newhtml = message.replace(/{total_amount}/g, roundNumber(totalFee));
       $('#extra_fee_msg').text(newhtml);
       $('#extra_fee_msg').show();
     }
-    return Math.round(totalFee * 100)/100;
+
+    return roundNumber(totalFee);
   }
   if (!payNowPayment) {
     displayTotalAmount(calculateTotalFee());


### PR DESCRIPTION
It turns out that on some web browsers (my version of firefox for
example), rounding numbers doesn't work as predictably as we would
expct.

For example:

Math.round(99.995 * 100)/100 => 100 (as expected)

But...

Math.round(77.475 * 100)/100 => 77.47 (what?!?)

The number is properly rounded by PHP on the backend. But displayed to
the user incorrectly.

This causes a visual discrepancy for the user, but also problems with
Stripe since one amount is used for the payment intent and then, when
the payment intent is applied on the backend, it's different and you
get the error:

payment_intent_unexpected_state

This PaymentIntent's amount could not be updated because it has a status
of requires_capture. You may only update the amount of a PaymentIntent
with one of the following statuses: requires_payment_method,
requires_confirmation, requires_action.