### PR TITLE
handle single quote in label

### DIFF
--- a/CRM/Extrafee/Fee.php
+++ b/CRM/Extrafee/Fee.php
@@ -41,7 +41,7 @@ class CRM_Extrafee_Fee {
   }
 
   public static function addOptionalFeeCheckbox($form, $extraFeeSettings) {
-    $form->add('checkbox', 'extra_fee_add', $extraFeeSettings['label']);
+    $form->add('checkbox', 'extra_fee_add', addslashes($extraFeeSettings['label']));
   }
 
   /**


### PR DESCRIPTION
Before: If your label has a single quote it causes a javascript parsing error.