### PR TITLE
Support multiple processors

### DIFF
--- a/CRM/Extrafee/Fee.php
+++ b/CRM/Extrafee/Fee.php
@@ -13,7 +13,7 @@ class CRM_Extrafee_Fee {
    * Display extra fee msg on payment page.
    */
   public static function displayFeeMessage($form, $extraFeeSettings) {
-    $processingFee = CRM_Utils_Array::value('processing_fee', $extraFeeSettings, 0);
+    $processingFee = (float) CRM_Utils_Array::value('processing_fee', $extraFeeSettings, 0);
     $percent = CRM_Utils_Array::value('percent', $extraFeeSettings, 0);
     $form->set('amount', 0);
     $form->assign('payNowPayment', FALSE);
@@ -28,8 +28,9 @@ class CRM_Extrafee_Fee {
         'id' => $form->_priceSetId,
       ]);
 
-      $form->assign('extraFeePercentage', $percent);
-      $form->assign('extraFeeProcessingFee', $processingFee);
+      $form->assign('processor_extra_fee_values', json_encode(self::getProcessorExtraFees()));
+      $form->assign('extra_fee_settings', json_encode($extraFeeSettings));
+
       $form->assign('extraFeeMessage', $extraFeeSettings['message']);
       $form->assign('extraFeeOptional', $extraFeeSettings['optional']);
       $form->assign('quick_config_display', $priceSet['is_quick_config']);
@@ -46,19 +47,29 @@ class CRM_Extrafee_Fee {
   /**
    *  Add % fee in submitted params.
    */
-  public static function modifyTotalAmountInParams($formName, &$form, $extraFeeSettings) {
+  public static function modifyTotalAmountInParams($formName, &$form, $extraFeeSettings, $ppId) {
     if (!empty($extraFeeSettings['optional']) && !CRM_Utils_Request::retrieveValue('extra_fee_add', 'String')) {
       return;
     }
     $processingFee = (float) CRM_Utils_Array::value('processing_fee', $extraFeeSettings, 0);
     $percent = CRM_Utils_Array::value('percent', $extraFeeSettings, 0);
+    $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+    if (!empty($ppExtraFeeSettings[$ppId]['percent'])) {
+      $percent = $ppExtraFeeSettings[$ppId]['percent'];
+    }
+    if (!empty($ppExtraFeeSettings[$ppId]['processing_fee'])) {
+      $processingFee = $ppExtraFeeSettings[$ppId]['processing_fee'];
+    }
+
     if ($formName == 'CRM_Contribute_Form_Contribution_Main') {
       if (!empty($form->_amount)) {
         $form->_amount += $form->_amount * $percent/100 + $processingFee;
+        $form->_amount = number_format($form->_amount, 2);
         $form->set('amount', $form->_amount);
       }
       elseif ($amt = $form->get('amount')) {
         $form->_amount = $amt + $amt * $percent/100 + $processingFee;
+        $form->_amount = number_format($form->_amount, 2);
         $form->set('amount', $form->_amount);
       }
     }
@@ -66,6 +77,7 @@ class CRM_Extrafee_Fee {
       $params = $form->getVar('_params');
       if (!empty($params[0]['amount'])) {
         $params[0]['amount'] += $params[0]['amount'] * $percent/100 + $processingFee;
+        $params[0]['amount'] = number_format($params[0]['amount'], 2);
         $form->setVar('_params', $params);
         $form->set('params', $params);
       }
@@ -77,8 +89,9 @@ class CRM_Extrafee_Fee {
    *
    * @param \CRM_Core_Form $form
    * @param array $extraFeeSettings
+   * @param array $ppExtraFeeSettings
    */
-  public static function isFormEligibleForExtraFee($form, $extraFeeSettings) {
+  public static function isFormEligibleForExtraFee($form, $extraFeeSettings, $ppExtraFeeSettings) {
     if (empty($extraFeeSettings['paymentprocessors'])) {
       // If we didn't set any payment processors we apply to all forms
       return TRUE;
@@ -93,8 +106,25 @@ class CRM_Extrafee_Fee {
         // We have matched on one of the processors we are enabled for
         return TRUE;
       }
+      // If processor has custom extra fee configured, return true.
+      if (!empty($ppExtraFeeSettings[$paymentProcessorID]['percent']) || !empty($ppExtraFeeSettings[$paymentProcessorID]['processing_fee'])) {
+        return TRUE;
+      }
     }
     return FALSE;
+  }
+
+  /**
+   * Get Extra fees overriden by payment processor.
+   */
+  public static function getProcessorExtraFees() {
+    $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+    foreach ($ppExtraFeeSettings as $ppID => $pp) {
+      if (empty($pp['percent'])) {
+        unset($ppExtraFeeSettings[$ppID]);
+      }
+    }
+    return $ppExtraFeeSettings;
   }
 
 }

--- a/CRM/Extrafee/Fee.php
+++ b/CRM/Extrafee/Fee.php
@@ -120,7 +120,7 @@ class CRM_Extrafee_Fee {
   public static function getProcessorExtraFees() {
     $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
     foreach ($ppExtraFeeSettings as $ppID => $pp) {
-      if (empty($pp['percent'])) {
+      if (empty($pp['percent']) && empty($pp['processing_fee'])) {
         unset($ppExtraFeeSettings[$ppID]);
       }
     }

--- a/CRM/Extrafee/Form/ExtraFeeSettings.php
+++ b/CRM/Extrafee/Form/ExtraFeeSettings.php
@@ -68,7 +68,7 @@ class CRM_Extrafee_Form_ExtraFeeSettings extends CRM_Core_Form {
       'label' => $values['extra_fee_label'] ?? NULL,
     ];
     Civi::settings()->set('extra_fee_settings', json_encode($extraFeeSettings));
-    CRM_Core_Session::setStatus(E::ts('You settings are saved.'), 'Success', 'success');
+    CRM_Core_Session::setStatus(E::ts('Your settings are saved.'), 'Success', 'success');
     parent::postProcess();
   }
 

--- a/extrafee.php
+++ b/extrafee.php
@@ -36,11 +36,33 @@ function extrafee_civicrm_install() {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
  */
 function extrafee_civicrm_buildForm($formName, &$form) {
+  if ($formName == 'CRM_Admin_Form_PaymentProcessor') {
+    $defaults = [];
+    if (!empty($form->_id)) {
+      $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+      if (isset($ppExtraFeeSettings[$form->_id])) {
+        $defaults = [
+          'extra_fee_percentage' => $ppExtraFeeSettings[$form->_id]['percent'] ?? NULL,
+          'extra_fee_processing_fee' => $ppExtraFeeSettings[$form->_id]['processing_fee'] ?? NULL,
+          'extra_fee_message' => $ppExtraFeeSettings[$form->_id]['message'] ?? NULL,
+        ];
+      }
+    }
+    $form->add('text', 'extra_fee_percentage', ts('Percentage'));
+    $form->add('text', 'extra_fee_processing_fee', ts('Processing Fee (Amount in Dollars)'));
+    $form->add('textarea', 'extra_fee_message', ts('Message'), ['rows' => 3, 'cols' => 45]);
+    $form->setDefaults($defaults);
+    $templatePath = realpath(dirname(__FILE__)."/templates");
+    CRM_Core_Region::instance('page-body')->add(array(
+      'template' => "{$templatePath}/CRM/Extrafee/Form/processor_extra_fee.tpl"
+    ));
+  }
   if (!in_array($formName, ['CRM_Contribute_Form_Contribution_Main', 'CRM_Event_Form_Registration_Register'])) {
     return;
   }
   $extraFeeSettings = json_decode(Civi::settings()->get('extra_fee_settings'), TRUE);
-  if (!CRM_Extrafee_Fee::isFormEligibleForExtraFee($form, $extraFeeSettings)) {
+  $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+  if (!CRM_Extrafee_Fee::isFormEligibleForExtraFee($form, $extraFeeSettings, $ppExtraFeeSettings)) {
     return;
   }
   if (!empty($extraFeeSettings['percent']) || !empty($extraFeeSettings['processing_fee'])) {
@@ -55,16 +77,27 @@ function extrafee_civicrm_buildForm($formName, &$form) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
  */
 function extrafee_civicrm_postProcess($formName, &$form) {
+  if ($formName == 'CRM_Admin_Form_PaymentProcessor') {
+    $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+    $ppExtraFeeSettings[$form->_id] = [
+      'percent' => $form->_submitValues['extra_fee_percentage'] ?? NULL,
+      'processing_fee' => $form->_submitValues['extra_fee_processing_fee'] ?? NULL,
+      'message' => addslashes($form->_submitValues['extra_fee_message']),
+    ];
+    Civi::settings()->set('processor_extra_fee_settings', json_encode($ppExtraFeeSettings));
+  }
+
   if (!in_array($formName, ['CRM_Contribute_Form_Contribution_Main', 'CRM_Event_Form_Registration_Register'])) {
     return;
   }
   $extraFeeSettings = json_decode(Civi::settings()->get('extra_fee_settings'), TRUE);
-  if (!CRM_Extrafee_Fee::isFormEligibleForExtraFee($form, $extraFeeSettings)) {
+  $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+  if (!CRM_Extrafee_Fee::isFormEligibleForExtraFee($form, $extraFeeSettings, $ppExtraFeeSettings)) {
     return;
   }
   $ppID = $form->getVar('_paymentProcessorID');
   if ((!empty($extraFeeSettings['percent']) || !empty($extraFeeSettings['processing_fee'])) && !empty($ppID) && empty($form->_ccid)) {
-    CRM_Extrafee_Fee::modifyTotalAmountInParams($formName, $form, $extraFeeSettings);
+    CRM_Extrafee_Fee::modifyTotalAmountInParams($formName, $form, $extraFeeSettings, $ppID);
   }
 }
 

--- a/templates/CRM/Extrafee/Form/processor_extra_fee.tpl
+++ b/templates/CRM/Extrafee/Form/processor_extra_fee.tpl
@@ -1,0 +1,27 @@
+<fieldset class='extra_fee_settings'>
+<legend>Extra Fee Settings</legend>
+  <table class="form-layout-compressed">
+    <tbody>
+      <tr class="crm-paymentProcessor-form-block-extra_fee_percentage">
+        <td class="label">{$form.extra_fee_percentage.label}</td>
+        <td>{$form.extra_fee_percentage.html}</td>
+      </tr>
+      <tr class="crm-paymentProcessor-form-block-extra_fee_processing_fee">
+        <td class="label">{$form.extra_fee_processing_fee.label}</td>
+        <td>{$form.extra_fee_processing_fee.html}</td>
+      </tr>
+      <tr class="crm-paymentProcessor-form-block-extra_fee_message">
+        <td class="label">{$form.extra_fee_message.label}</td>
+        <td>{$form.extra_fee_message.html}</td>
+      </tr>
+    </tbody>
+  </table>
+</fieldset>
+
+<script type="text/javascript">
+{literal}
+CRM.$(function($) {
+  $(".extra_fee_settings").insertAfter($( ".crm-paymentProcessor-form-block table:eq(0)"));
+});
+{/literal}
+</script>

--- a/templates/extra_fee.tpl
+++ b/templates/extra_fee.tpl
@@ -100,6 +100,7 @@ CRM.$(function($) {
           processingFee = extra_fee_settings['processing_fee'];
           message = extra_fee_settings['message'];
         }
+        percent = parseFloat(percent) || 0;
         processingFee = parseFloat(processingFee) || 0;
         totalFee += (parseFloat(totalFee) * parseFloat(percent) / 100 + processingFee);
       }

--- a/templates/extra_fee.tpl
+++ b/templates/extra_fee.tpl
@@ -1,10 +1,11 @@
 {literal}
 <script>
 CRM.$(function($) {
+  var processor_extrafee = {/literal} {if $processor_extra_fee_values} {$processor_extra_fee_values} {else} 0 {/if}{literal};
+  var extra_fee_settings = {/literal} {if $extra_fee_settings} {$extra_fee_settings} {else} 0 {/if}{literal};
+
   var isQuickConfig = {/literal}{$quick_config_display}{literal};
   var payNowPayment = {/literal} {if $payNowPayment} {$payNowPayment} {else} 0 {/if}{literal};
-  var percent = {/literal} {if $extraFeePercentage} {$extraFeePercentage} {else} 0 {/if}{literal};
-  var processingFee = {/literal} {if $extraFeeProcessingFee} {$extraFeeProcessingFee} {else} 0 {/if}{literal};
   var message = {/literal} {if $extraFeeMessage} '{$extraFeeMessage}' {else} '' {/if}{literal};
   var thousandMarker = '{/literal}{$config->monetaryThousandSeparator}{literal}';
   var separator      = '{/literal}{$config->monetaryDecimalPoint}{literal}';
@@ -46,6 +47,7 @@ CRM.$(function($) {
     precision = 2;
     return (+(Math.round(+(num + 'e' + precision)) + 'e' + -precision)).toFixed(precision);
   }
+
   function displayTotalAmount(totalfee) {
     totalfee = roundNumber(totalfee);
     var totalEventFee  = formatExtraFee( totalfee, 2, separator, thousandMarker);
@@ -88,7 +90,18 @@ CRM.$(function($) {
     }
     if (typeof pp !== 'undefined' && pp != 0 && totalFee) {
       if (addExtraFee) {
-        totalFee += (totalFee * percent / 100 + processingFee);
+        if (processor_extrafee !== null && typeof processor_extrafee[pp] !== 'undefined') {
+          percent = processor_extrafee[pp]['percent'];
+          processingFee = processor_extrafee[pp]['processing_fee'];
+          message = processor_extrafee[pp]['message'];
+        }
+        else if (typeof extra_fee_settings !== 'undefined') {
+          percent = extra_fee_settings['percent'];
+          processingFee = extra_fee_settings['processing_fee'];
+          message = extra_fee_settings['message'];
+        }
+        processingFee = parseFloat(processingFee) || 0;
+        totalFee += (parseFloat(totalFee) * parseFloat(percent) / 100 + processingFee);
       }
     }
     $('#extra_fee_msg').hide();


### PR DESCRIPTION
Support multiple processors to set extra fees.

- Configure processor speecific custom extra fee by navigating to the processor form `Administer => CiviContribute => Payment Processor`- 

![image](https://user-images.githubusercontent.com/5929648/204132160-6ef3581f-af42-42f9-a3fd-2166c5dd1462.png)

These values will override the percent configured on the Extrafee Settings page - `/civicrm/extrafeesettings`.

If a contribution page has multiple payment processors, the overriden values will be applied for the selected payment processor.