### PR TITLE
fix php8 warnings

### DIFF
--- a/CRM/Extrafee/Fee.php
+++ b/CRM/Extrafee/Fee.php
@@ -53,7 +53,7 @@ class CRM_Extrafee_Fee {
     }
     $processingFee = (float) CRM_Utils_Array::value('processing_fee', $extraFeeSettings, 0);
     $percent = CRM_Utils_Array::value('percent', $extraFeeSettings, 0);
-    $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+    $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings') ?? '', TRUE);
     if (!empty($ppExtraFeeSettings[$ppId]['percent'])) {
       $percent = $ppExtraFeeSettings[$ppId]['percent'];
     }
@@ -106,6 +106,10 @@ class CRM_Extrafee_Fee {
         // We have matched on one of the processors we are enabled for
         return TRUE;
       }
+      // Exit current loop if there is no payment processor id.
+      if (empty($ppExtraFeeSettings[$paymentProcessorID])) {
+        continue;
+      }
       // If processor has custom extra fee configured, return true.
       if (!empty($ppExtraFeeSettings[$paymentProcessorID]['percent']) || !empty($ppExtraFeeSettings[$paymentProcessorID]['processing_fee'])) {
         return TRUE;
@@ -118,13 +122,14 @@ class CRM_Extrafee_Fee {
    * Get Extra fees overriden by payment processor.
    */
   public static function getProcessorExtraFees() {
-    $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
-    foreach ($ppExtraFeeSettings as $ppID => $pp) {
-      if (empty($pp['percent']) && empty($pp['processing_fee'])) {
-        unset($ppExtraFeeSettings[$ppID]);
+    $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings') ?? '', TRUE);
+    if ($ppExtraFeeSettings) {
+      foreach ($ppExtraFeeSettings as $ppID => $pp) {
+        if (empty($pp['percent']) && empty($pp['processing_fee'])) {
+          unset($ppExtraFeeSettings[$ppID]);
+        }
+      }
+      return $ppExtraFeeSettings;
       }
     }
-    return $ppExtraFeeSettings;
-  }
-
 }

--- a/extrafee.php
+++ b/extrafee.php
@@ -39,7 +39,7 @@ function extrafee_civicrm_buildForm($formName, &$form) {
   if ($formName == 'CRM_Admin_Form_PaymentProcessor') {
     $defaults = [];
     if (!empty($form->_id)) {
-      $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+      $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings') ?? '', TRUE);
       if (isset($ppExtraFeeSettings[$form->_id])) {
         $defaults = [
           'extra_fee_percentage' => $ppExtraFeeSettings[$form->_id]['percent'] ?? NULL,
@@ -60,8 +60,8 @@ function extrafee_civicrm_buildForm($formName, &$form) {
   if (!in_array($formName, ['CRM_Contribute_Form_Contribution_Main', 'CRM_Event_Form_Registration_Register'])) {
     return;
   }
-  $extraFeeSettings = json_decode(Civi::settings()->get('extra_fee_settings'), TRUE);
-  $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+  $extraFeeSettings = json_decode(Civi::settings()->get('extra_fee_settings') ?? '', TRUE);
+  $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings') ?? '', TRUE);
   if (!CRM_Extrafee_Fee::isFormEligibleForExtraFee($form, $extraFeeSettings, $ppExtraFeeSettings)) {
     return;
   }
@@ -78,7 +78,7 @@ function extrafee_civicrm_buildForm($formName, &$form) {
  */
 function extrafee_civicrm_postProcess($formName, &$form) {
   if ($formName == 'CRM_Admin_Form_PaymentProcessor') {
-    $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+    $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings') ?? '', TRUE);
     $ppExtraFeeSettings[$form->_id] = [
       'percent' => $form->_submitValues['extra_fee_percentage'] ?? NULL,
       'processing_fee' => $form->_submitValues['extra_fee_processing_fee'] ?? NULL,
@@ -90,8 +90,8 @@ function extrafee_civicrm_postProcess($formName, &$form) {
   if (!in_array($formName, ['CRM_Contribute_Form_Contribution_Main', 'CRM_Event_Form_Registration_Register'])) {
     return;
   }
-  $extraFeeSettings = json_decode(Civi::settings()->get('extra_fee_settings'), TRUE);
-  $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings'), TRUE);
+  $extraFeeSettings = json_decode(Civi::settings()->get('extra_fee_settings') ?? '', TRUE);
+  $ppExtraFeeSettings = json_decode(Civi::settings()->get('processor_extra_fee_settings') ?? '', TRUE);
   if (!CRM_Extrafee_Fee::isFormEligibleForExtraFee($form, $extraFeeSettings, $ppExtraFeeSettings)) {
     return;
   }


### PR DESCRIPTION
**Overview**
When installed on a site using php8, this extension will throw several warnings.


**Before** 
Because of how the settings are set up for this extension, it is possible for `$ppExtraFeeSettings` and `$extraFeeSettings` to be NULL, however, when NULL is passed to `json_decode()` it throws a warning with php8.

```
Deprecated function: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in CRM_Extrafee_Fee::getProcessorExtraFees() (line 121 of sites/all/civicrm-custom/extensions/nz.co.fuzion.extrafee/CRM/Extrafee/Fee.php). 

Warning: foreach() argument must be of type array|object, null given in CRM_Extrafee_Fee::getProcessorExtraFees() (line 122 of sites/all/civicrm-custom/extensions/nz.co.fuzion.extrafee/CRM/Extrafee/Fee.php). 

Deprecated function: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in CRM_Extrafee_Fee::modifyTotalAmountInParams() (line 56 of sites/all/civicrm-custom/extensions/nz.co.fuzion.extrafee/CRM/Extrafee/Fee.php).

Deprecated function: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in extrafee_civicrm_buildForm() (line 64 of sites/all/civicrm-custom/extensions/nz.co.fuzion.extrafee/extrafee.php). 
```

**After**
This PR adds the null coalescing operator and passes an empty string, i.e. `?? ''` to the calls to `json_decode()` to prevent some of the above warnings.
This code also uses a conditional and a continuation from a `foreach` loop if the variables are empty to prevent additional php8 warnings.