### PR TITLE
fix regression from civi 5.69+ fix

### DIFF
--- a/CRM/Extrafee/Fee.php
+++ b/CRM/Extrafee/Fee.php
@@ -68,7 +68,6 @@ class CRM_Extrafee_Fee extends CRM_Contribute_Form_ContributionBase {
       $selectedOnContributionPage = $form->_params['extra_fee_add'] ?? FALSE;
       $selectedOnEventPage = $params[0]['extra_fee_add'] ?? FALSE;
       if (!$selectedOnContributionPage && !$selectedOnEventPage) {
-        \Civi::log()->debug("Bailing");
         return;
       }
     }


### PR DESCRIPTION
The fix in https://github.com/fuzionnz/nz.co.fuzion.extrafee/pull/29 in inadvertently broke the calculation of extra fees on event pages. 