### PR TITLE
Fix rounding error on contribution page submission

### DIFF
--- a/CRM/Extrafee/Fee.php
+++ b/CRM/Extrafee/Fee.php
@@ -82,6 +82,8 @@ class CRM_Extrafee_Fee extends CRM_Contribute_Form_ContributionBase {
     ])) {
       if (!empty($form->_params['amount'])) {
         $extrafee_amount = $form->_params['amount'] * $percent/100 + $processingFee;
+        $extrafee_amount = round(CRM_Utils_Rule::cleanMoney($extrafee_amount), 2);
+
         $lineItems = $form->getOrder()->getLineItems();
         if (!empty($lineItems)) {
           $financialTypeId = reset($lineItems)['financial_type_id'] ?? 1;


### PR DESCRIPTION
![image](https://github.com/fuzionnz/nz.co.fuzion.extrafee/assets/5929648/fb68d09e-45dc-465a-9b9f-a02036c256ac)

On payment with % = 1.7, processing fee = 0.2

Donation amount = 5
Including extra fee is calculated as 5.285

Expected calculated amount should be rounded to 5.29